### PR TITLE
Change Lock to LockInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0
+### Changed 
+- `LockManager` now takes and return `LockInterface` instead of `Lock` which implements it 
+
 ## 0.1.1
 ### Changed
 - Downgraded `phpunit` to `^6.0` to have PHP7.0 dev compatibility

--- a/src/Service/LockManager.php
+++ b/src/Service/LockManager.php
@@ -4,7 +4,7 @@ namespace Paysera\Bundle\LockBundle\Service;
 
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Factory;
-use Symfony\Component\Lock\Lock;
+use Symfony\Component\Lock\LockInterface;
 
 class LockManager
 {
@@ -19,12 +19,12 @@ class LockManager
         $this->ttl = $ttl;
     }
 
-    public function createLock(string $resource): Lock
+    public function createLock(string $resource): LockInterface
     {
         return $this->lockFactory->createLock($resource, $this->ttl);
     }
 
-    public function acquire(Lock $lock): bool
+    public function acquire(LockInterface $lock): bool
     {
         foreach (range(1, $this->ttl) as $waited) {
             if ($lock->acquire()) {
@@ -41,7 +41,7 @@ class LockManager
         throw new LockAcquiringException('Failed to acquire lock');
     }
 
-    public function createAcquired(string $resource): Lock
+    public function createAcquired(string $resource): LockInterface
     {
         $lock = $this->createLock($resource);
         $this->acquire($lock);
@@ -49,7 +49,7 @@ class LockManager
         return $lock;
     }
 
-    public function release(Lock $lock)
+    public function release(LockInterface $lock)
     {
         $lock->release();
     }


### PR DESCRIPTION
Changing argument and return types from Lock to LockInterface will let us to easily mock Locks in unit tests. Also to create our own locks