### PR TITLE
Change setArgument to replaceArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1
+### Changed
+- `PayseraLockExtension` Definition method **setArgument** is replaced to **replaceArgument** so bundle will work properly on Symfony ^2.8
+
 ## 0.2.0
 ### Changed 
 - `LockManager` now takes and return `LockInterface` instead of `Lock` which implements it 

--- a/src/DependencyInjection/PayseraLockExtension.php
+++ b/src/DependencyInjection/PayseraLockExtension.php
@@ -26,6 +26,6 @@ class PayseraLockExtension extends Extension
     private function configureLockStore(ContainerBuilder $container, array $config)
     {
         $storeDefinition = $container->getDefinition('paysera_lock.lock_store');
-        $storeDefinition->setArgument(0, new Reference($config['redis_client']));
+        $storeDefinition->replaceArgument(0, new Reference($config['redis_client']));
     }
 }


### PR DESCRIPTION
Bundle does not work properly on Symfony >2.8 - <3.3 because Definition::setArgument was introduced in Symfony 3.3. 