### PR TITLE
Fixed failure of lock acquirement during concurrent requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0
+### Changed
+- `\Paysera\Bundle\LockBundle\Service\LockManager::createLock` now creates lock without TTL
+- Added strict type declaration in `\Paysera\Bundle\LockBundle\Service\LockManager`
+- Updated README.md
+
 ## 0.2.1
 ### Changed
 - `PayseraLockExtension` Definition method **setArgument** is replaced to **replaceArgument** so bundle will work properly on Symfony ^2.8

--- a/README.md
+++ b/README.md
@@ -3,8 +3,24 @@
 Provides quick integration with `symfony/lock`
 
 ### Installation
+- Install package
 ```bash
 composer require paysera/lib-lock-bundle
+```
+- Enable bundle
+```php
+class AppKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        $bundles = [
+            // ...
+            new Paysera\Bundle\LockBundle\PayseraLockBundle(),
+        ];
+
+        // ...
+    }
+}
 ```
 
 ### Configuration
@@ -30,13 +46,13 @@ paysera_lock:
 $lock = $this->lockManager->createLock($identifier);
 try {
     $this->lockManager->acquire($lock);
+    
+    // do something after aquiring lock
 } catch (LockAcquiringException $exception) {
     throw new Exception('...');
+} finally {
+    $lock->release();
 }
-
-// do something when got lock
-
-$lock->release();
 ```
 OR
 ```php
@@ -47,5 +63,4 @@ try {
 }
 
 // do rest
-
 ```

--- a/src/Service/LockManager.php
+++ b/src/Service/LockManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_type=1);
+
 namespace Paysera\Bundle\LockBundle\Service;
 
 use Symfony\Component\Lock\Exception\LockAcquiringException;
@@ -21,7 +23,7 @@ class LockManager
 
     public function createLock(string $resource): LockInterface
     {
-        return $this->lockFactory->createLock($resource, $this->ttl);
+        return $this->lockFactory->createLock($resource, null);
     }
 
     public function acquire(LockInterface $lock): bool


### PR DESCRIPTION
Second lock acquirement fails if there is execution delay after first lock acquirement

Quick PoC:
```
$a = $this->createLock('a');
$b = $this->createLock('a');

$this->lockManager->acquire($a);

// this simulates code execution time, without this delay everything works as expected
// bug most likely caused because non-null TTL causes lock refresh after each acquirement attempt, see https://github.com/symfony/lock/blob/3.3/Lock.php#L64 
sleep(1);

$this->lockManager->acquire($b);

$this->lockManager->release($b);

$this->lockManager->release($a);
```